### PR TITLE
Remove hardcoded default dev host

### DIFF
--- a/addon/services/adapter.js
+++ b/addon/services/adapter.js
@@ -8,7 +8,7 @@ const {
 } = Ember;
 
 function buildUrl(adapter, url) {
-  let host = getWithDefault(adapter, 'host', 'http://localhost:4200');
+  let host = getWithDefault(adapter, 'host');
   let namespace = get(adapter, 'namespace');
 
   let parts = [host];
@@ -17,7 +17,12 @@ function buildUrl(adapter, url) {
   }
   parts.push(url);
 
-  return parts.join('/');
+  let combined = parts.join('/');
+  if (!host && combined && combined.charAt(0) !== '/') {
+    combined = '/' + combined;
+  }
+
+  return combined;
 }
 
 export default Service.extend({

--- a/addon/services/adapter.js
+++ b/addon/services/adapter.js
@@ -8,7 +8,7 @@ const {
 } = Ember;
 
 function buildUrl(adapter, url) {
-  let host = getWithDefault(adapter, 'host');
+  let host = getWithDefault(adapter, 'host', '');
   let namespace = get(adapter, 'namespace');
 
   let parts = [host];
@@ -17,12 +17,7 @@ function buildUrl(adapter, url) {
   }
   parts.push(url);
 
-  let combined = parts.join('/');
-  if (!host && combined && combined.charAt(0) !== '/') {
-    combined = '/' + combined;
-  }
-
-  return combined;
+  return parts.join('/');
 }
 
 export default Service.extend({

--- a/tests/unit/services/adapter-test.js
+++ b/tests/unit/services/adapter-test.js
@@ -64,11 +64,11 @@ test('returns adapter.ajax response', function(assert) {
   });
 });
 
-test('uses default host if not supplied', function(assert) {
+test('uses a relative url if host not supplied', function(assert) {
   delete adapter.host;
 
   return service.ajax('test-url').then(() => {
-    assert.deepEqual(ajaxStub.args, [['http://localhost:4200/test-namespace/test-url']]);
+    assert.deepEqual(ajaxStub.args, [['/test-namespace/test-url']]);
   });
 });
 


### PR DESCRIPTION
Uses relative URL if host is absent, roughly the same behavior as from ember-data build-url-mixin.
Relevant test updated to check for relative URL rather than the default dev host.